### PR TITLE
Add initial keyboard firmware framework

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,7 @@ dependencies = [
  "cortex-m",
  "cortex-m-rt",
  "panic-halt",
+ "stm32h7",
 ]
 
 [[package]]

--- a/bootloader/Cargo.toml
+++ b/bootloader/Cargo.toml
@@ -7,4 +7,5 @@ edition = "2024"
 cortex-m = "0.7"
 cortex-m-rt = "0.7"
 panic-halt = "0.2"
+stm32h7 = { version = "0.16", features = ["stm32h723", "rt"] }
 

--- a/bootloader/src/main.rs
+++ b/bootloader/src/main.rs
@@ -1,9 +1,27 @@
 #![no_std]
 #![no_main]
+use cortex_m::asm;
 use cortex_m_rt::entry;
 use panic_halt as _;
+use stm32h7::stm32h723;
+
+const APP_BASE: u32 = 0x0800_8000;
 
 #[entry]
 fn main() -> ! {
+    let dp = stm32h723::Peripherals::take().unwrap();
+
+    // enable port C clock to read a key or button on PC13
+    dp.RCC.ahb4enr().modify(|_, w| w.gpiocen().set_bit());
+    dp.GPIOC.moder().modify(|_, w| w.moder13().input());
+    dp.GPIOC.pupdr().modify(|_, w| w.pupdr13().pull_up());
+
+    let pressed = dp.GPIOC.idr().read().idr13().bit_is_clear();
+
+    if !pressed {
+        unsafe { asm::bootload(APP_BASE as *const u32) };
+    }
+
+    // Stay in bootloader (update mode)
     loop {}
 }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -10,5 +10,7 @@ path = "src/lib.rs"
 crate-type = ["rlib"]
 
 [features]
-default = []
+default = ["direct-keys"]
 std = []
+direct-keys = []
+matrix-scan = []

--- a/core/src/direct.rs
+++ b/core/src/direct.rs
@@ -1,0 +1,14 @@
+use crate::{KeyboardHW, Timer};
+
+pub fn process<H: KeyboardHW, T: Timer>(hw: &mut H, timer: &T) {
+    let mut last = hw.read_keys();
+    loop {
+        let now = timer.millis();
+        let state = hw.read_keys();
+        if state != last {
+            // placeholder for event handling in firmware/sim
+            last = state;
+        }
+        let _ = now; // suppress unused variable
+    }
+}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,14 +1,47 @@
 #![no_std]
 
-/// Hardware-agnostic keyboard logic will live here.
+/// Type representing the pressed state of up to 32 keys.
+/// Each bit corresponds to a key.
+pub type KeyState = u32;
 
+/// Abstraction over the hardware keyboard interface.  This trait is
+/// implemented by the STM32 firmware as well as the Linux simulator.
 pub trait KeyboardHW {
+    /// Perform any one time initialisation of the hardware.
     fn init(&mut self) {}
-    fn read_keys(&self) -> u32 { 0 }
+
+    /// Read the current key state.  For a matrix this reads the currently
+    /// active row; for direct wiring it reads all keys.
+    fn read_keys(&self) -> KeyState {
+        0
+    }
+
+    /// Activate a row in a matrix keyboard.  Direct keyboards can ignore this.
+    fn set_row_active(&mut self, _row: usize) {}
+
+    /// Deactivate all rows.
+    fn set_all_rows_inactive(&mut self) {}
 }
 
-pub fn run<H: KeyboardHW>(hw: &mut H) {
+/// Simple timer abstraction used by the debouncing logic.
+pub trait Timer {
+    /// Return milliseconds since startup.
+    fn millis(&self) -> u64;
+}
+
+#[cfg(feature = "direct-keys")]
+mod direct;
+#[cfg(feature = "matrix-scan")]
+mod matrix;
+
+/// Run the active keyboard algorithm.  This function never returns on the
+/// firmware but in the simulator it may exit once the test scenario completes.
+pub fn run<H: KeyboardHW, T: Timer>(hw: &mut H, timer: &T) {
     hw.init();
-    let _state = hw.read_keys();
-    let _ = _state; // placeholder
+
+    #[cfg(feature = "matrix-scan")]
+    matrix::process(hw, timer);
+
+    #[cfg(feature = "direct-keys")]
+    direct::process(hw, timer);
 }

--- a/core/src/matrix.rs
+++ b/core/src/matrix.rs
@@ -1,0 +1,16 @@
+use crate::{KeyState, KeyboardHW, Timer};
+
+const NUM_ROWS: usize = 4;
+
+pub fn process<H: KeyboardHW, T: Timer>(hw: &mut H, timer: &T) {
+    let mut stable: [KeyState; NUM_ROWS] = [0; NUM_ROWS];
+    loop {
+        for row in 0..NUM_ROWS {
+            hw.set_row_active(row);
+            let val = hw.read_keys();
+            stable[row] = val;
+        }
+        hw.set_all_rows_inactive();
+        let _ = timer.millis();
+    }
+}

--- a/firmware/Cargo.toml
+++ b/firmware/Cargo.toml
@@ -10,3 +10,8 @@ stm32h7 = { version = "0.16", features = ["stm32h723", "rt"] }
 keyboard_core = { package = "keyboard-core", path = "../core" }
 panic-halt = "0.2"
 
+[features]
+default = ["direct-keys"]
+direct-keys = ["keyboard_core/direct-keys"]
+matrix-scan = ["keyboard_core/matrix-scan"]
+

--- a/firmware/src/main.rs
+++ b/firmware/src/main.rs
@@ -1,19 +1,66 @@
 #![no_std]
 #![no_main]
+use cortex_m::peripheral::{Peripherals, SYST};
 use cortex_m_rt::entry;
+use keyboard_core::{self as core, KeyboardHW, Timer};
 use panic_halt as _;
-use keyboard_core::{self as core, KeyboardHW};
+use stm32h7::stm32h723;
 
-struct Stm32Keyboard;
+const SYSCLK_HZ: u32 = 64_000_000; // placeholder clock
+
+struct Stm32Keyboard {
+    gpio: stm32h723::GPIOC,
+}
+
+impl Stm32Keyboard {
+    fn new(dp: stm32h723::Peripherals) -> Self {
+        Stm32Keyboard { gpio: dp.GPIOC }
+    }
+}
+
+struct SysTimer {
+    syst: SYST,
+    start: u64,
+}
+
+impl Timer for SysTimer {
+    fn millis(&self) -> u64 {
+        // Placeholder implementation; a real firmware would track elapsed
+        // milliseconds using an interrupt or the DWT cycle counter.
+        let _ = self.syst.cvr.read();
+        0
+    }
+}
 
 impl KeyboardHW for Stm32Keyboard {
-    fn init(&mut self) {}
-    fn read_keys(&self) -> u32 { 0 }
+    fn init(&mut self) {
+        // enable port C clock
+        let rcc = unsafe { &(*stm32h723::RCC::ptr()) };
+        rcc.ahb4enr().modify(|_, w| w.gpiocen().set_bit());
+
+        // configure PC13 as input with pull-up as an example
+        self.gpio.moder().modify(|_, w| w.moder13().input());
+        self.gpio.pupdr().modify(|_, w| w.pupdr13().pull_up());
+    }
+
+    fn read_keys(&self) -> u32 {
+        let idr = self.gpio.idr().read().bits();
+        (!idr >> 13) & 1
+    }
 }
 
 #[entry]
 fn main() -> ! {
-    let mut hw = Stm32Keyboard;
-    core::run(&mut hw);
+    let dp = stm32h723::Peripherals::take().unwrap();
+    let cp = Peripherals::take().unwrap();
+
+    let mut hw = Stm32Keyboard::new(dp);
+    let mut syst = cp.SYST;
+    syst.set_reload(SYSCLK_HZ / 1000);
+    syst.clear_current();
+    syst.enable_counter();
+    let timer = SysTimer { syst, start: 0 };
+
+    core::run(&mut hw, &timer);
     loop {}
 }

--- a/simulator/src/main.rs
+++ b/simulator/src/main.rs
@@ -1,13 +1,31 @@
-use keyboard_core::{self as core, KeyboardHW};
+use keyboard_core::{self as core, KeyboardHW, Timer};
+use std::time::Instant;
 
 struct SimKeyboard;
 
 impl KeyboardHW for SimKeyboard {
     fn init(&mut self) {}
-    fn read_keys(&self) -> u32 { 0 }
+    fn read_keys(&self) -> u32 {
+        0
+    }
+}
+
+struct HostTimer(Instant);
+
+impl HostTimer {
+    fn new() -> Self {
+        HostTimer(Instant::now())
+    }
+}
+
+impl Timer for HostTimer {
+    fn millis(&self) -> u64 {
+        self.0.elapsed().as_millis() as u64
+    }
 }
 
 fn main() {
     let mut hw = SimKeyboard;
-    core::run(&mut hw);
+    let timer = HostTimer::new();
+    core::run(&mut hw, &timer);
 }


### PR DESCRIPTION
## Summary
- flesh out hardware-agnostic core crate with traits
- implement placeholder direct and matrix algorithms
- stub out STM32 firmware and bootloader logic
- add simple Linux simulator with host timer

## Testing
- `cargo build --target thumbv7em-none-eabihf -p firmware -p bootloader --quiet`

------
https://chatgpt.com/codex/tasks/task_e_687b4f58e660832d827720e0ff232038