### PR TITLE
Add compile-time key processing algorithms

### DIFF
--- a/core/src/matrix.rs
+++ b/core/src/matrix.rs
@@ -1,14 +1,34 @@
-use crate::{KeyState, KeyboardHW, Timer};
-
+use crate::{KeyEventHandler, KeyState, KeyboardHW, Timer};
 const NUM_ROWS: usize = 4;
-
-pub fn process<H: KeyboardHW, T: Timer>(hw: &mut H, timer: &T) {
-    let mut stable: [KeyState; NUM_ROWS] = [0; NUM_ROWS];
+const NUM_COLS: usize = 8;
+const NUM_KEYS: usize = NUM_ROWS * NUM_COLS;
+const DEBOUNCE_BITS: u8 = 5;
+const MASK: u16 = (1 << DEBOUNCE_BITS) - 1;
+pub fn process<H, T, E>(hw: &mut H, timer: &T, handler: &mut E)
+where
+    H: KeyboardHW,
+    T: Timer,
+    E: KeyEventHandler,
+{
+    let mut history = [0u16; NUM_KEYS];
+    let mut stable: KeyState = 0;
     loop {
         for row in 0..NUM_ROWS {
             hw.set_row_active(row);
             let val = hw.read_keys();
-            stable[row] = val;
+            for col in 0..NUM_COLS {
+                let idx = row * NUM_COLS + col;
+                let bit = ((val >> col) & 1) as u16;
+                history[idx] = ((history[idx] << 1) | bit) & MASK;
+                let cur = (stable >> idx) & 1;
+                if history[idx] == MASK && cur == 0 {
+                    stable |= 1 << idx;
+                    handler.key_event(idx, true);
+                } else if history[idx] == 0 && cur == 1 {
+                    stable &= !(1 << idx);
+                    handler.key_event(idx, false);
+                }
+            }
         }
         hw.set_all_rows_inactive();
         let _ = timer.millis();

--- a/firmware/src/main.rs
+++ b/firmware/src/main.rs
@@ -2,7 +2,7 @@
 #![no_main]
 use cortex_m::peripheral::{Peripherals, SYST};
 use cortex_m_rt::entry;
-use keyboard_core::{self as core, KeyboardHW, Timer};
+use keyboard_core::{self as core, KeyEventHandler, KeyboardHW, Timer};
 use panic_halt as _;
 use stm32h7::stm32h723;
 
@@ -21,6 +21,14 @@ impl Stm32Keyboard {
 struct SysTimer {
     syst: SYST,
     start: u64,
+}
+
+struct EventSink;
+
+impl KeyEventHandler for EventSink {
+    fn key_event(&mut self, _key: usize, _pressed: bool) {
+        // in real firmware this would update USB HID reports
+    }
 }
 
 impl Timer for SysTimer {
@@ -60,7 +68,8 @@ fn main() -> ! {
     syst.clear_current();
     syst.enable_counter();
     let timer = SysTimer { syst, start: 0 };
+    let mut events = EventSink;
 
-    core::run(&mut hw, &timer);
+    core::run(&mut hw, &timer, &mut events);
     loop {}
 }

--- a/simulator/src/main.rs
+++ b/simulator/src/main.rs
@@ -1,4 +1,4 @@
-use keyboard_core::{self as core, KeyboardHW, Timer};
+use keyboard_core::{self as core, KeyEventHandler, KeyboardHW, Timer};
 use std::time::Instant;
 
 struct SimKeyboard;
@@ -7,6 +7,14 @@ impl KeyboardHW for SimKeyboard {
     fn init(&mut self) {}
     fn read_keys(&self) -> u32 {
         0
+    }
+}
+
+struct PrintHandler;
+
+impl KeyEventHandler for PrintHandler {
+    fn key_event(&mut self, key: usize, pressed: bool) {
+        println!("key {} {}", key, if pressed { "down" } else { "up" });
     }
 }
 
@@ -27,5 +35,6 @@ impl Timer for HostTimer {
 fn main() {
     let mut hw = SimKeyboard;
     let timer = HostTimer::new();
-    core::run(&mut hw, &timer);
+    let mut handler = PrintHandler;
+    core::run(&mut hw, &timer, &mut handler);
 }


### PR DESCRIPTION
## Summary
- implement `KeyEventHandler` trait and run() signature
- add debouncing algorithms for direct keys and matrix scanning
- update firmware and simulator to handle events

## Testing
- `cargo check --workspace --exclude firmware --exclude bootloader`
- `cargo check --target thumbv7em-none-eabihf -p firmware -p bootloader`
- `cargo test --workspace --exclude firmware --exclude bootloader`


------
https://chatgpt.com/codex/tasks/task_e_687b51e62a28832da27e81f57df57f38