### PR TITLE
Add configurable debouncers

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -10,7 +10,10 @@ path = "src/lib.rs"
 crate-type = ["rlib"]
 
 [features]
-default = ["direct-keys"]
+default = ["direct-keys", "time-debounce"]
 std = []
 direct-keys = []
 matrix-scan = []
+no-debounce = []
+time-debounce = []
+mask-debounce = []

--- a/core/src/debounce.rs
+++ b/core/src/debounce.rs
@@ -1,0 +1,141 @@
+// Debouncer implementations and trait
+
+use crate::KeyState;
+
+pub trait Debouncer {
+    /// Update debouncer with raw key state and current time in milliseconds.
+    /// Returns: (debounced state, newly pressed mask, newly released mask)
+    fn update(&mut self, raw: KeyState, time_ms: u64) -> (KeyState, KeyState, KeyState);
+}
+
+/// No debouncing - pass raw state through.
+pub struct NoDebounce {
+    prev_state: KeyState,
+}
+
+impl NoDebounce {
+    pub fn new() -> Self {
+        Self { prev_state: 0 }
+    }
+}
+
+impl Default for NoDebounce {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Debouncer for NoDebounce {
+    fn update(&mut self, raw: KeyState, _t: u64) -> (KeyState, KeyState, KeyState) {
+        let changed = raw ^ self.prev_state;
+        let pressed = changed & raw;
+        let released = changed & !raw;
+        self.prev_state = raw;
+        (raw, pressed, released)
+    }
+}
+
+/// Time based debouncer. Each key must be stable for `debounce_ms` before state changes.
+pub struct TimeDebounce {
+    last_change: [u64; 64],
+    stable_state: KeyState,
+    debounce_ms: u64,
+}
+
+impl TimeDebounce {
+    pub fn new(debounce_ms: u64) -> Self {
+        Self {
+            last_change: [0; 64],
+            stable_state: 0,
+            debounce_ms,
+        }
+    }
+}
+
+impl Default for TimeDebounce {
+    fn default() -> Self {
+        Self::new(5)
+    }
+}
+
+impl Debouncer for TimeDebounce {
+    fn update(&mut self, raw: KeyState, now: u64) -> (KeyState, KeyState, KeyState) {
+        let mut pressed = 0;
+        let mut released = 0;
+        for i in 0..64 {
+            let mask = 1u64 << i;
+            let is_now = raw & mask != 0;
+            let was = self.stable_state & mask != 0;
+            if is_now != was {
+                if now - self.last_change[i] >= self.debounce_ms {
+                    if is_now {
+                        pressed |= mask;
+                    } else {
+                        released |= mask;
+                    }
+                    self.stable_state ^= mask;
+                    self.last_change[i] = now;
+                }
+            } else {
+                self.last_change[i] = now;
+            }
+        }
+        (self.stable_state, pressed, released)
+    }
+}
+
+/// Bit mask history debouncer. A key must be seen in the same state for `threshold` consecutive scans.
+pub struct MaskDebounce {
+    history: [u8; 64],
+    state: KeyState,
+    threshold: u8,
+}
+
+impl MaskDebounce {
+    pub fn new(threshold: u8) -> Self {
+        Self {
+            history: [0; 64],
+            state: 0,
+            threshold,
+        }
+    }
+}
+
+impl Default for MaskDebounce {
+    fn default() -> Self {
+        Self::new(5)
+    }
+}
+
+impl Debouncer for MaskDebounce {
+    fn update(&mut self, raw: KeyState, _now: u64) -> (KeyState, KeyState, KeyState) {
+        let mut pressed = 0;
+        let mut released = 0;
+        for i in 0..64 {
+            let mask = 1u64 << i;
+            let bit = if raw & mask != 0 { 1 } else { 0 };
+            self.history[i] = (self.history[i] << 1) | bit;
+            let ones = self.history[i].count_ones() as u8;
+            let cur = self.state & mask != 0;
+            if ones == self.threshold {
+                if bit == 1 && !cur {
+                    self.state |= mask;
+                    pressed |= mask;
+                } else if bit == 0 && cur {
+                    self.state &= !mask;
+                    released |= mask;
+                }
+            }
+        }
+        (self.state, pressed, released)
+    }
+}
+
+#[cfg(feature = "no-debounce")]
+pub type ActiveDebouncer = NoDebounce;
+
+#[cfg(feature = "time-debounce")]
+pub type ActiveDebouncer = TimeDebounce;
+
+#[cfg(feature = "mask-debounce")]
+pub type ActiveDebouncer = MaskDebounce;

--- a/core/src/direct.rs
+++ b/core/src/direct.rs
@@ -1,5 +1,8 @@
 use crate::{ActiveDebouncer, Debouncer, KeyEventHandler, KeyboardHW, Timer};
 
+#[cfg(not(any(feature = "no-debounce", feature = "time-debounce", feature = "mask-debounce")))]
+compile_error!("A debounce implementation feature must be enabled");
+
 const NUM_KEYS: usize = 32;
 
 pub fn process<H, T, E>(hw: &mut H, timer: &T, handler: &mut E)

--- a/core/src/direct.rs
+++ b/core/src/direct.rs
@@ -1,8 +1,6 @@
-use crate::{KeyEventHandler, KeyState, KeyboardHW, Timer};
+use crate::{ActiveDebouncer, Debouncer, KeyEventHandler, KeyboardHW, Timer};
 
 const NUM_KEYS: usize = 32;
-const DEBOUNCE_BITS: u8 = 5;
-const MASK: u16 = (1 << DEBOUNCE_BITS) - 1;
 
 pub fn process<H, T, E>(hw: &mut H, timer: &T, handler: &mut E)
 where
@@ -10,22 +8,18 @@ where
     T: Timer,
     E: KeyEventHandler,
 {
-    let mut history = [0u16; NUM_KEYS];
-    let mut stable: KeyState = hw.read_keys();
+    let mut debouncer = ActiveDebouncer::default();
     loop {
         let raw = hw.read_keys();
+        let (_state, pressed, released) = debouncer.update(raw, timer.millis());
         for i in 0..NUM_KEYS {
-            let bit = ((raw >> i) & 1) as u16;
-            history[i] = ((history[i] << 1) | bit) & MASK;
-            let cur = (stable >> i) & 1;
-            if history[i] == MASK && cur == 0 {
-                stable |= 1u64 << i;
+            let mask = 1u64 << i;
+            if pressed & mask != 0 {
                 handler.key_event(i, true);
-            } else if history[i] == 0 && cur == 1 {
-                stable &= !(1u64 << i);
+            }
+            if released & mask != 0 {
                 handler.key_event(i, false);
             }
         }
-        let _ = timer.millis();
     }
 }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -9,6 +9,9 @@ extern crate std;
 /// Each bit corresponds to a key.
 pub type KeyState = u64;
 
+pub mod debounce;
+pub use debounce::{ActiveDebouncer, Debouncer, MaskDebounce, NoDebounce, TimeDebounce};
+
 /// Abstraction over the hardware keyboard interface.  This trait is
 /// implemented by the STM32 firmware as well as the Linux simulator.
 pub trait KeyboardHW {

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -10,7 +10,9 @@ extern crate std;
 pub type KeyState = u64;
 
 pub mod debounce;
-pub use debounce::{ActiveDebouncer, Debouncer, MaskDebounce, NoDebounce, TimeDebounce};
+pub use debounce::{Debouncer, MaskDebounce, NoDebounce, TimeDebounce};
+#[cfg(any(feature = "no-debounce", feature = "time-debounce", feature = "mask-debounce"))]
+pub use debounce::ActiveDebouncer;
 
 /// Abstraction over the hardware keyboard interface.  This trait is
 /// implemented by the STM32 firmware as well as the Linux simulator.

--- a/core/src/matrix.rs
+++ b/core/src/matrix.rs
@@ -1,4 +1,7 @@
 use crate::{ActiveDebouncer, Debouncer, KeyEventHandler, KeyboardHW, Timer};
+
+#[cfg(not(any(feature = "no-debounce", feature = "time-debounce", feature = "mask-debounce")))]
+compile_error!("A debounce implementation feature must be enabled");
 const NUM_ROWS: usize = 4;
 const NUM_COLS: usize = 8;
 const NUM_KEYS: usize = NUM_ROWS * NUM_COLS;

--- a/core/src/matrix.rs
+++ b/core/src/matrix.rs
@@ -1,36 +1,38 @@
-use crate::{KeyEventHandler, KeyState, KeyboardHW, Timer};
+use crate::{ActiveDebouncer, Debouncer, KeyEventHandler, KeyboardHW, Timer};
 const NUM_ROWS: usize = 4;
 const NUM_COLS: usize = 8;
 const NUM_KEYS: usize = NUM_ROWS * NUM_COLS;
-const DEBOUNCE_BITS: u8 = 5;
-const MASK: u16 = (1 << DEBOUNCE_BITS) - 1;
 pub fn process<H, T, E>(hw: &mut H, timer: &T, handler: &mut E)
 where
     H: KeyboardHW,
     T: Timer,
     E: KeyEventHandler,
 {
-    let mut history = [0u16; NUM_KEYS];
-    let mut stable: KeyState = 0;
+    let mut debouncer = ActiveDebouncer::default();
     loop {
+        let mut raw_state = 0u64;
         for row in 0..NUM_ROWS {
             hw.set_row_active(row);
             let val = hw.read_keys();
             for col in 0..NUM_COLS {
-                let idx = row * NUM_COLS + col;
-                let bit = ((val >> col) & 1) as u16;
-                history[idx] = ((history[idx] << 1) | bit) & MASK;
-                let cur = (stable >> idx) & 1;
-                if history[idx] == MASK && cur == 0 {
-                    stable |= 1u64 << idx;
-                    handler.key_event(idx, true);
-                } else if history[idx] == 0 && cur == 1 {
-                    stable &= !(1u64 << idx);
-                    handler.key_event(idx, false);
+                if (val >> col) & 1 != 0 {
+                    let idx = row * NUM_COLS + col;
+                    raw_state |= 1u64 << idx;
                 }
             }
         }
         hw.set_all_rows_inactive();
-        let _ = timer.millis();
+
+        let (state, pressed, released) = debouncer.update(raw_state, timer.millis());
+        let _ = state;
+        for i in 0..NUM_KEYS {
+            let mask = 1u64 << i;
+            if pressed & mask != 0 {
+                handler.key_event(i, true);
+            }
+            if released & mask != 0 {
+                handler.key_event(i, false);
+            }
+        }
     }
 }

--- a/firmware/Cargo.toml
+++ b/firmware/Cargo.toml
@@ -14,4 +14,7 @@ panic-halt = "0.2"
 default = ["direct-keys"]
 direct-keys = ["keyboard_core/direct-keys"]
 matrix-scan = ["keyboard_core/matrix-scan"]
+no-debounce = ["keyboard_core/no-debounce"]
+time-debounce = ["keyboard_core/time-debounce"]
+mask-debounce = ["keyboard_core/mask-debounce"]
 

--- a/simulator/Cargo.toml
+++ b/simulator/Cargo.toml
@@ -7,3 +7,8 @@ edition = "2021"
 keyboard-core = { path = "../core", default-features = false, features = ["std"] }
 chrono = "0.4"
 
+[features]
+no-debounce = ["keyboard-core/no-debounce"]
+time-debounce = ["keyboard-core/time-debounce"]
+mask-debounce = ["keyboard-core/mask-debounce"]
+


### PR DESCRIPTION
## Summary
- add Debouncer trait with three implementations
- expose ActiveDebouncer selected via features
- switch matrix and direct scanners to use ActiveDebouncer
- provide feature flags in each crate

## Testing
- `cargo check --workspace --exclude firmware --exclude bootloader`
- `cargo test --workspace --exclude firmware --exclude bootloader --no-run`
- `cargo run --bin simulator --quiet`

------
https://chatgpt.com/codex/tasks/task_e_687c780385ac832db4af0b9f13571ebf