### PR TITLE
Setup firmware build script and basic tests

### DIFF
--- a/core/src/logic.rs
+++ b/core/src/logic.rs
@@ -1,4 +1,4 @@
-use crate::{KeyboardHW, Timer, KeyEventHandler, KeyState};
+use crate::{KeyEventHandler, KeyState, KeyboardHW, Timer};
 
 const NUM_ROWS: usize = 4;
 const NUM_COLS: usize = 8;
@@ -44,5 +44,11 @@ impl KeyboardLogic {
         }
         hw.set_all_rows_inactive();
         let _ = timer.millis();
+    }
+}
+
+impl Default for KeyboardLogic {
+    fn default() -> Self {
+        Self::new()
     }
 }

--- a/firmware/.cargo/config.toml
+++ b/firmware/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+target = "thumbv7em-none-eabihf"

--- a/firmware/build.rs
+++ b/firmware/build.rs
@@ -1,7 +1,7 @@
 fn main() {
     println!(
         "cargo:rustc-link-search={}",
-        std::env::var("CARGO_MANIFEST_DIR").unwrap()
+        std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR environment variable is not set")
     );
     println!("cargo:rustc-link-arg=-Tmemory.x");
     println!("cargo:rerun-if-changed=memory.x");

--- a/firmware/build.rs
+++ b/firmware/build.rs
@@ -1,0 +1,8 @@
+fn main() {
+    println!(
+        "cargo:rustc-link-search={}",
+        std::env::var("CARGO_MANIFEST_DIR").unwrap()
+    );
+    println!("cargo:rustc-link-arg=-Tmemory.x");
+    println!("cargo:rerun-if-changed=memory.x");
+}

--- a/simulator/src/main.rs
+++ b/simulator/src/main.rs
@@ -3,7 +3,7 @@ mod input_scenario;
 
 use sim_hal::{SimKeyboard, SimTimer};
 use input_scenario::example_scenario;
-use keyboard_core::{KeyboardHW, Timer};
+use keyboard_core::KeyboardHW;
 
 fn scan_and_process(hw: &mut impl KeyboardHW, time: u64) {
     let keys = hw.read_keys();

--- a/simulator/src/sim_hal.rs
+++ b/simulator/src/sim_hal.rs
@@ -18,6 +18,7 @@ impl SimKeyboard {
     }
 
     pub fn set_key(&mut self, row: usize, col: usize, pressed: bool) {
+        assert!(row < self.num_rows && col < self.num_cols);
         let bit_index = row * self.num_cols + col;
         if pressed {
             self.keys |= 1 << bit_index;
@@ -52,6 +53,7 @@ impl KeyboardHW for SimKeyboard {
     }
 
     fn set_row_active(&mut self, row: usize) {
+        assert!(row < self.num_rows);
         self.active_row = Some(row);
     }
 


### PR DESCRIPTION
## Summary
- add default implementation for `KeyboardLogic`
- adjust simulator HAL to drop unused field
- switch simulator to use new constructor signature
- add minimal build.rs linking `memory.x`
- set firmware build target through `.cargo/config.toml`
- add compile-check tests for core and simulator crates
- remove placeholder tests, restore simulator HAL with rows

## Testing
- `cargo clippy -p keyboard-core -p simulator -- -D warnings`
- `cargo test -p keyboard-core`
- `cargo test -p simulator`
- `cargo check -p firmware --target thumbv7em-none-eabihf`
- `cargo check -p bootloader --target thumbv7em-none-eabihf`
- `cargo build -p firmware --release --target thumbv7em-none-eabihf`


------
https://chatgpt.com/codex/tasks/task_e_687ff197e194832d8108fa5793e1f153